### PR TITLE
Update swift-tools-support-core to 0.6.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "b7667f3e266af621e5cc9c77e74cacd8e8c00cb4",
-          "version": "0.2.5"
+          "revision": "3b13e439a341bbbfe0f710c7d1be37221745ef1a",
+          "version": "0.6.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.0")),
+        .package(url: "https://github.com/apple/swift-tools-support-core", from: "0.6.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
We have the use case for a command line tool depending on `ProjectAutomation` and a newer `swift-tools-support-core` version. The current `.upToNextMinor(from: "0.2.0")` requirement is too restrictive for this, so I raised it to version 0.6.1, which is the same version that is used by `tuist` itself.