### PR TITLE
4.45.1

### DIFF
--- a/ProjectAutomation/Configuration.swift
+++ b/ProjectAutomation/Configuration.swift
@@ -2,10 +2,10 @@ import Foundation
 
 // MARK: - Configuration
 
-// A the build Configuration of a target.
+// The build Configuration of a target.
 
 public struct Configuration: Equatable, Codable {
-    let settings: SettingsDictionary
+    private let settings: SettingsDictionary
 
     public init(
         settings: SettingsDictionary
@@ -16,19 +16,16 @@ public struct Configuration: Equatable, Codable {
 
 // MARK: - BuildConfiguration
 
-public struct BuildConfiguration: Equatable, Codable, Hashable {
-    public enum Variant: String, Codable, Hashable {
+public struct BuildConfiguration: Codable, Hashable {
+    public enum Variant: Codable {
         case debug
         case release
     }
 
-    public var name: String
-    public var variant: BuildConfiguration.Variant
+    private let name: String
+    private let variant: Variant
 
-    public init(
-        name: String,
-        variant: BuildConfiguration.Variant
-    ) {
+    public init(name: String, variant: Variant) {
         self.name = name
         self.variant = variant
     }

--- a/ProjectAutomation/Configuration.swift
+++ b/ProjectAutomation/Configuration.swift
@@ -2,10 +2,10 @@ import Foundation
 
 // MARK: - Configuration
 
-// The build Configuration of a target.
+// A the build Configuration of a target.
 
-public struct Configuration: Equatable, Codable {
-    private let settings: SettingsDictionary
+public struct Configuration: Equatable, Codable, Sendable {
+    let settings: SettingsDictionary
 
     public init(
         settings: SettingsDictionary
@@ -16,16 +16,19 @@ public struct Configuration: Equatable, Codable {
 
 // MARK: - BuildConfiguration
 
-public struct BuildConfiguration: Codable, Hashable {
-    public enum Variant: Codable {
+public struct BuildConfiguration: Equatable, Codable, Hashable, Sendable {
+    public enum Variant: String, Codable, Hashable, Sendable {
         case debug
         case release
     }
 
-    private let name: String
-    private let variant: Variant
+    public var name: String
+    public var variant: BuildConfiguration.Variant
 
-    public init(name: String, variant: Variant) {
+    public init(
+        name: String,
+        variant: BuildConfiguration.Variant
+    ) {
         self.name = name
         self.variant = variant
     }
@@ -33,7 +36,7 @@ public struct BuildConfiguration: Codable, Hashable {
 
 public typealias SettingsDictionary = [String: SettingValue]
 
-public enum SettingValue: Equatable, Codable {
+public enum SettingValue: Equatable, Codable, Sendable {
     case string(value: String)
     case array(value: [String])
 

--- a/ProjectAutomation/Graph.swift
+++ b/ProjectAutomation/Graph.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The structure defining the output schema of the entire project graph.
-public struct Graph: Codable, Equatable {
+public struct Graph: Codable, Equatable, Sendable {
     /// The name of this graph.
     public let name: String
 

--- a/ProjectAutomation/Package.swift
+++ b/ProjectAutomation/Package.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 /// The structure defining the output schema of the Swift package.
-public struct Package: Codable, Equatable {
+public struct Package: Codable, Equatable, Sendable {
     /// The type of the Swift package.
-    public enum PackageKind: String, Codable {
+    public enum PackageKind: String, Codable, Sendable {
         case remote
         case local
     }

--- a/ProjectAutomation/Project.swift
+++ b/ProjectAutomation/Project.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The structure defining the output schema of a Xcode project.
-public struct Project: Codable, Equatable {
+public struct Project: Codable, Equatable, Sendable {
     /// The name of the project.
     public let name: String
 

--- a/ProjectAutomation/Scheme.swift
+++ b/ProjectAutomation/Scheme.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The structure defining the output schema of an Xcode scheme.
-public struct Scheme: Codable, Equatable {
+public struct Scheme: Codable, Equatable, Sendable {
     /// The name of the scheme.
     public let name: String
 

--- a/ProjectAutomation/Settings.swift
+++ b/ProjectAutomation/Settings.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // A group of settings configurations.
 
-public struct Settings: Equatable, Codable {
+public struct Settings: Equatable, Codable, Sendable {
     public var configurations: [ProjectAutomation.BuildConfiguration: ProjectAutomation.Configuration?]
 
     public init(

--- a/ProjectAutomation/Target.swift
+++ b/ProjectAutomation/Target.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The structure defining the output schema of a target.
-public struct Target: Codable, Equatable {
+public struct Target: Codable, Equatable, Sendable {
     /// The name of the target.
     public let name: String
 

--- a/ProjectAutomation/TargetDependency.swift
+++ b/ProjectAutomation/TargetDependency.swift
@@ -1,24 +1,27 @@
 import Foundation
 
-public enum FrameworkStatus: String, Codable {
+public enum LinkingStatus: String, Codable, Sendable {
     case required
     case optional
+    case none
 }
 
-public enum SDKStatus: String, Codable {
-    case required
-    case optional
-}
+@available(*, deprecated, renamed: "LinkingStatus")
+typealias FrameworkStatus = LinkingStatus
 
-public enum TargetDependency: Equatable, Hashable, Codable {
-    case target(name: String)
-    case project(target: String, path: String)
-    case framework(path: String, status: FrameworkStatus)
-    case xcframework(path: String, status: FrameworkStatus)
+@available(*, deprecated, renamed: "LinkingStatus")
+typealias SDKStatus = LinkingStatus
+
+public enum TargetDependency: Equatable, Hashable, Codable, Sendable {
+    case target(name: String, status: LinkingStatus)
+    case macro(name: String)
+    case project(target: String, path: String, status: LinkingStatus)
+    case framework(path: String, status: LinkingStatus)
+    case xcframework(path: String, status: LinkingStatus)
     case library(path: String, publicHeaders: String, swiftModuleMap: String?)
-    case package(product: String)
+    case package(product: String, embedded: Bool = false)
     case packagePlugin(product: String)
     case packageMacro(product: String)
-    case sdk(name: String, status: SDKStatus)
+    case sdk(name: String, status: LinkingStatus)
     case xctest
 }

--- a/ProjectAutomation/Task.swift
+++ b/ProjectAutomation/Task.swift
@@ -1,16 +1,16 @@
 import Foundation
 
-public struct Task {
+public struct Task: Sendable {
     public let options: [Option]
-    public let task: ([String: String]) throws -> Void
+    public let task: @Sendable ([String: String]) throws -> Void
 
-    public enum Option: Equatable {
+    public enum Option: Equatable, Sendable {
         case option(String)
     }
 
     public init(
         options: [Option] = [],
-        task: @escaping ([String: String]) throws -> Void
+        task: @Sendable @escaping ([String: String]) throws -> Void
     ) {
         self.options = options
         self.task = task
@@ -19,10 +19,10 @@ public struct Task {
     }
 
     private func runIfNeeded() {
-        guard let taskCommandLineIndex = CommandLine.arguments.firstIndex(of: "--tuist-task"),
+        guard let taskCommandLineIndex = ProcessInfo.processInfo.arguments.firstIndex(of: "--tuist-task"),
               CommandLine.argc > taskCommandLineIndex
         else { return }
-        let attributesString = CommandLine.arguments[taskCommandLineIndex + 1]
+        let attributesString = ProcessInfo.processInfo.arguments[taskCommandLineIndex + 1]
         // swiftlint:disable force_try
         let attributes: [String: String] = try! JSONDecoder().decode(
             [String: String].self,

--- a/ProjectAutomation/Tuist.swift
+++ b/ProjectAutomation/Tuist.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Tuist includes all methods to interact with your tuist project
 public enum Tuist {
-    enum TuistError: Error {
+    enum TuistError: Error, Sendable {
         case signalled(command: String, code: Int32, standardError: Data)
         case terminated(command: String, code: Int32, standardError: Data)
 

--- a/ProjectAutomation/Tuist.swift
+++ b/ProjectAutomation/Tuist.swift
@@ -34,7 +34,7 @@ public enum Tuist {
             var arguments = [
                 "tuist",
                 "graph",
-                "--format", "json",
+                "--format", "legacyJSON",
                 "--output-path", temporaryDirectory.path,
             ]
             if let path {


### PR DESCRIPTION
Yes, we're using it) And it broke when we tried to update from 4.9.0 to 4.39.1.

If we use this repo with 4.39.1 tuist cli it fails with Codable type mismatch 

```swift
typeMismatch(Swift.String, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "projects", intValue: nil), _CodingKey(stringValue: "/Users/mk/dev/plata/ios/bank/Project/App", intValue: nil), CodingKeys(stringValue: "targets", intValue: nil), _CodingKey(stringValue: "Index 1", intValue: 1), CodingKeys(stringValue: "settings", intValue: nil), CodingKeys(stringValue: "configurations", intValue: nil), _CodingKey(stringValue: "Index 0", intValue: 0), CodingKeys(stringValue: "variant", intValue: nil)], debugDescription: "Expected to decode String but found a dictionary instead.", underlyingError: nil))
```

The naive solution is to sync the repo manually with the main one, which I did here. The more robust option would be to trigger the downstream pipeline to copy ProjectAutomation folder here with each release regardless if it changed or not. We can merge this and I can implement the pipeline.

What do you think?